### PR TITLE
Configure JitPack build with RAT and Chekstyle skipped

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+install:
+    - mvn install -Drat.ignoreErrors=true -Dcheckstyle.skip=true -DskipTests
+


### PR DESCRIPTION
Hello,

I understand that this project is experimental and as such is not yet stable to get published to Central.

However I think that to have feedbacks it must be available in some way (other than building it locally, to avoid extra logic in CI descriptors).
To be honnest, I want to use it and see if it can improve how tests are done in the **maven-dependency-plugin**, (continuing [maven-dependency-plugin#29](https://github.com/apache/maven-dependency-plugin/pull/29)).

So I tried [JiPack](https://jitpack.io/#khmarbaise/maven-it-extension) which is great for that.

However the default command used by JitPack (`mvn install -DskipTests`) breaks.

So here is the configuration for JitPack that mimics the one used in GitHub actions.