### PR TITLE
add a maven-polyglot test using takari yaml extension

### DIFF
--- a/itf-examples/pom.xml
+++ b/itf-examples/pom.xml
@@ -134,7 +134,7 @@
         </configuration>
         <executions>
           <execution>
-            <id>standard</id>
+            <id>default</id>
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
@@ -171,7 +171,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <executions>
               <execution>
-                <id>standard</id>
+                <id>default</id>
                 <phase>none</phase>
               </execution>
               <execution>

--- a/itf-examples/pom.xml
+++ b/itf-examples/pom.xml
@@ -134,10 +134,14 @@
         </configuration>
         <executions>
           <execution>
+            <id>standard</id>
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+            <configuration>
+              <excludedGroups>Failing</excludedGroups>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -156,7 +160,34 @@
         </executions>
       </plugin>
     </plugins>
-
   </build>
-
+  
+  <profiles>
+    <profile>
+      <id>failing</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>standard</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>failing</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <groups>Failing</groups>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/itf-examples/src/test/java/com/soebes/itf/examples/polyglot/PolyglotIT.java
+++ b/itf-examples/src/test/java/com/soebes/itf/examples/polyglot/PolyglotIT.java
@@ -1,0 +1,37 @@
+package com.soebes.itf.examples.polyglot;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+import org.junit.jupiter.api.Tag;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+@MavenJupiterExtension
+@Tag("Failing")
+public class PolyglotIT {
+  
+  @MavenTest
+  void yaml(MavenExecutionResult result) {
+    assertThat(result).isSuccessful();
+  }
+}

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/.mvn/extensions.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/.mvn/extensions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<extensions>
+  <extension>
+    <groupId>io.takari.polyglot</groupId>
+    <artifactId>polyglot-yaml</artifactId>
+    <version>0.4.5</version>
+  </extension>
+</extensions>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/.polyglot.pom.yaml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/.polyglot.pom.yaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.soebes.itf.examples.polyglot</groupId>
+  <artifactId>yaml-project</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>ITF using YAML POM</name>
+</project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/pom.yaml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/pom.yaml
@@ -1,0 +1,5 @@
+modelVersion: 4.0.0
+groupId: com.soebes.itf.examples.polyglot
+artifactId: yaml-project
+version: 0.0.1-SNAPSHOT
+name: 'ITF using YAML POM'


### PR DESCRIPTION
This is a simple contribution with an example of a test on a maven project using a core extension.
In this case, I used the [polyglot-maven](https://github.com/takari/polyglot-maven) takari extension and more precisely the yaml polyglot one.

As the introduced tests demo that ITF does not support core extension manipulating the POM (as Object Model), I also introduced a profile for the introduced "Failing" test.

Normal commands will not be impacted and the failing tests are exlcluded from the normal build.
They have to be explicitly run by using the profile `failing` on the example project using `mvn -Pfailing verify`

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
