### PR TITLE
intoduction of a maven-polyglot test using takari yaml extension

### DIFF
--- a/itf-examples/src/test/java/com/soebes/itf/examples/polyglot/PolyglotIT.java
+++ b/itf-examples/src/test/java/com/soebes/itf/examples/polyglot/PolyglotIT.java
@@ -1,0 +1,36 @@
+package com.soebes.itf.examples.polyglot;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+@MavenJupiterExtension
+public class PolyglotIT {
+  
+  @MavenTest
+  void yaml(MavenExecutionResult result) {
+    // we expect to be able to execute ITF on a project using takari polyglot maven core extension 
+    assertThat(result).isSuccessful();
+  }
+}

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/.mvn/extensions.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/.mvn/extensions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<extensions>
+  <extension>
+    <groupId>io.takari.polyglot</groupId>
+    <artifactId>polyglot-yaml</artifactId>
+    <version>0.4.5</version>
+  </extension>
+</extensions>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/pom.yaml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/polyglot/PolyglotIT/yaml/pom.yaml
@@ -1,0 +1,5 @@
+modelVersion: 4.0.0
+groupId: com.soebes.itf.examples.polyglot
+artifactId: yaml-project
+version: 0.0.1-SNAPSHOT
+name: 'ITF using YAML POM'


### PR DESCRIPTION
In replacement of #158, I simplified the introduction of an IT test using [maven-polyglot](https://github.com/takari/polyglot-maven) takari core extension.

The build is failing since ITF pre-tests tasks fail while to read a `pom.xml` file that does not exist.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

Closes #44