### PR TITLE
Example and support for MavenSourceProject

### DIFF
--- a/itf-examples/src/test/java/com/soebes/itf/examples/MavenSourceProjectIT.java
+++ b/itf-examples/src/test/java/com/soebes/itf/examples/MavenSourceProjectIT.java
@@ -1,0 +1,144 @@
+package com.soebes.itf.examples;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import com.soebes.itf.jupiter.extension.MavenGoal;
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenOption;
+import com.soebes.itf.jupiter.extension.MavenProject;
+import com.soebes.itf.jupiter.extension.MavenSourceProject;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.extension.SystemProperty;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+@MavenJupiterExtension
+@MavenSourceProject("com/soebes/itf/examples/source/class-level")
+class MavenSourceProjectIT {
+
+  @MavenTest
+  @MavenGoal("help:evaluate")
+  @SystemProperty(value = "expression", content = "class.level")
+  void class_level_source_project(MavenExecutionResult result) {
+    assertThat(result)
+            .isSuccessful()
+            .out()
+            .plain()
+            .contains("default-class-property");
+  }
+
+  @MavenTest
+  @MavenGoal("help:evaluate")
+  @SystemProperty(value = "expression", content = "class.level")
+  @SystemProperty(value = "class.level", content = "test-property")
+  void class_level_source_project_custom_value(MavenExecutionResult result) {
+    assertThat(result)
+            .isSuccessful()
+            .out()
+            .plain()
+            .contains("test-property");
+  }
+
+  @MavenTest
+  @MavenGoal("help:evaluate")
+  @SystemProperty(value = "expression", content = "method.level")
+  @MavenSourceProject("com/soebes/itf/examples/source/method-level")
+  void method_level_source_project(MavenExecutionResult result) {
+    assertThat(result)
+            .isSuccessful()
+            .out()
+            .plain()
+            .contains("default-method-property");
+  }
+
+  @MavenTest
+  @MavenGoal("help:evaluate")
+  @SystemProperty(value = "expression", content = "method.level")
+  @SystemProperty(value = "method.level", content = "test-property")
+  @MavenSourceProject("com/soebes/itf/examples/source/method-level")
+  void method_level_source_project_custom_value(MavenExecutionResult result) {
+    assertThat(result)
+            .isSuccessful()
+            .out()
+            .plain()
+            .contains("test-property");
+  }
+
+  @Nested
+  @MavenSourceProject("com/soebes/itf/examples/source/nested-class-level")
+  class NestedExample {
+
+    @MavenTest
+    @MavenGoal("help:evaluate")
+    @SystemProperty(value = "expression", content = "nested.class.level")
+    void class_level_source_project(MavenExecutionResult result) {
+      assertThat(result)
+              .isSuccessful()
+              .out()
+              .plain()
+              .contains("default-nested-class-property");
+    }
+
+    @MavenTest
+    @MavenGoal("help:evaluate")
+    @SystemProperty(value = "expression", content = "nested.class.level")
+    @SystemProperty(value = "nested.class.level", content = "test-property")
+    void class_level_source_project_custom_value(MavenExecutionResult result) {
+      assertThat(result)
+              .isSuccessful()
+              .out()
+              .plain()
+              .contains("test-property");
+    }
+
+    @MavenTest
+    @MavenGoal("help:evaluate")
+    @SystemProperty(value = "expression", content = "method.level")
+    @MavenSourceProject("com/soebes/itf/examples/source/method-level")
+    void method_level_source_project(MavenExecutionResult result) {
+      assertThat(result)
+              .isSuccessful()
+              .out()
+              .plain()
+              .contains("default-method-property");
+    }
+
+    @MavenTest
+    @MavenGoal("help:evaluate")
+    @SystemProperty(value = "expression", content = "method.level")
+    @SystemProperty(value = "method.level", content = "test-property")
+    @MavenSourceProject("com/soebes/itf/examples/source/method-level")
+    void method_level_source_project_custom_value(MavenExecutionResult result) {
+      assertThat(result)
+              .isSuccessful()
+              .out()
+              .plain()
+              .contains("test-property");
+    }
+
+  }
+
+}

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/source/class-level/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/source/class-level/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.source.project</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <class.level>default-class-property</class.level>
+  </properties>
+
+</project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/source/method-level/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/source/method-level/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.source.project</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <method.level>default-method-property</method.level>
+  </properties>
+
+</project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/source/nested-class-level/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/source/nested-class-level/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.source.project</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <nested.class.level>default-nested-class-property</nested.class.level>
+  </properties>
+
+</project>

--- a/itf-jupiter-extension/src/main/java/com/soebes/itf/jupiter/extension/AnnotationHelper.java
+++ b/itf-jupiter-extension/src/main/java/com/soebes/itf/jupiter/extension/AnnotationHelper.java
@@ -151,6 +151,20 @@ class AnnotationHelper {
     return Optional.empty();
   }
 
+  private static <T extends Annotation> Optional<T> findAnnotationInHierarchy(ExtensionContext context,
+                                                   Class<T> annotationClass) {
+    Optional<ExtensionContext> current = Optional.of(context);
+    while (current.isPresent()) {
+      ExtensionContext currentContext = current.get();
+      Optional<T> annotation = AnnotationSupport.findAnnotation(currentContext.getElement(), annotationClass);
+      if (annotation.isPresent()) {
+        return annotation;
+      }
+      current = currentContext.getParent();
+    }
+    return Optional.empty();
+  }
+
   static Optional<Class<?>> findMavenRepositoryAnnotation(ExtensionContext context) {
     return findAnnotation(context, MavenRepository.class);
   }
@@ -161,6 +175,10 @@ class AnnotationHelper {
 
   static Optional<Class<?>> findMavenPredefinedRepositoryAnnotation(ExtensionContext context) {
     return findAnnotation(context, MavenPredefinedRepository.class);
+  }
+
+  static Optional<MavenSourceProject> findMavenSourceProjectAnnotation(ExtensionContext context) {
+    return findAnnotationInHierarchy(context, MavenSourceProject.class);
   }
 
 }

--- a/itf-jupiter-extension/src/main/java/com/soebes/itf/jupiter/extension/DirectoryResolverResult.java
+++ b/itf-jupiter-extension/src/main/java/com/soebes/itf/jupiter/extension/DirectoryResolverResult.java
@@ -106,7 +106,11 @@ class DirectoryResolverResult {
 
 
     File intermediate = new File(this.targetTestClassesDirectory, toFullyQualifiedPath);
-    if (mavenProject.isPresent()) {
+    Optional<MavenSourceProject> mavenSourceProject = AnnotationHelper.findMavenSourceProjectAnnotation(context);
+
+    if (mavenSourceProject.isPresent()) {
+      this.sourceMavenProject = new File(this.targetTestClassesDirectory, mavenSourceProject.get().value());
+    } else if (mavenProject.isPresent()) {
       MavenProject mavenProjectAnnotation = mavenProject.get().getAnnotation(MavenProject.class);
       this.sourceMavenProject = new File(intermediate, mavenProjectAnnotation.value());
     } else {

--- a/itf-jupiter-extension/src/main/java/com/soebes/itf/jupiter/extension/MavenSourceProject.java
+++ b/itf-jupiter-extension/src/main/java/com/soebes/itf/jupiter/extension/MavenSourceProject.java
@@ -1,0 +1,43 @@
+package com.soebes.itf.jupiter.extension;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@API(status = EXPERIMENTAL, since = "TBD")
+public @interface MavenSourceProject {
+
+  String value();
+}


### PR DESCRIPTION
This PR is an example for issue #232. It showcases how a new `@MavenSourceProject` annotation can be used to create dedicated individual tests using a single source project.


This checklist will help us to incorporate your contribution quickly and easily:

 - [x] Make sure you have read the [contributing guide](https://github.com/khmarbaise/maven-it-extension/blob/master/CONTRIBUTION.md).
 - [x] Make sure there is a [issue](https://github.com/khmarbaise/maven-it-extension/issues) filed 
       for the change (usually before you start working on it). Trivial changes like typos do not 
       require a issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Name your branch which contains the pull request accordingly with the issue. 
       Best is to follow: `issue-Number` where `Number` has be replaced with the issue
       number of the appropriate issue you are offering a pull request for.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `Fixed #Nr - Fixed IT execution.`,
       where you replace `Nr` with the appropriate issue number. It is required 
       to use the issue title in the commit message title and in the first line of the 
       commit message. They should very similar like the following: `Fixed #64 - Automatic site publishing`
       You can of course take a look into the existing commit history.
 - [ ] Make an appropriate entry into the release notes. Follow the examples
       of the existing release notes.
 - [ x Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).


 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
