### PR TITLE
Fixed #398 - Make Build working with JDK21

### DIFF
--- a/itf-documentation/src/main/asciidoc/release-notes/_release-notes-0.13.0.adoc
+++ b/itf-documentation/src/main/asciidoc/release-notes/_release-notes-0.13.0.adoc
@@ -50,6 +50,7 @@
 :issue-392: https://github.com/khmarbaise/maven-it-extension/issues/392[Fixed #392]
 :issue-394: https://github.com/khmarbaise/maven-it-extension/issues/394[Fixed #394]
 :issue-396: https://github.com/khmarbaise/maven-it-extension/issues/396[Fixed #396]
+:issue-398: https://github.com/khmarbaise/maven-it-extension/issues/398[Fixed #398]
 :issue-399: https://github.com/khmarbaise/maven-it-extension/issues/399[Fixed #399]
 :issue-??: https://github.com/khmarbaise/maven-it-extension/issues/??[Fixed #??]
 
@@ -123,5 +124,7 @@
  * {issue-351} - JDK17+ Usage in Tests
  * {issue-381} - Improved structuring of documentation.
  * {issue-382} - Fixed output directory for html/pdf files.
+ * {issue-398} - Make Build working with JDK21.
+
 
 The full release notes can be found here {release_0_13_0}[Release 0.13.0].

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/defaults/DefaultsForAllIT/option_debug/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/defaults/DefaultsForAllIT/option_debug/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/GoalsIT/goal_clean/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/GoalsIT/goal_clean/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/GoalsIT/goal_clean_compile/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/GoalsIT/goal_clean_compile/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/GoalsIT/no_goals_at_all/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/GoalsIT/no_goals_at_all/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/GoalsOnClassIT/goal_clean/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/GoalsOnClassIT/goal_clean/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/MetaAnnotationGoalIT/clean_verify/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/goals/MetaAnnotationGoalIT/clean_verify/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/mps/xyz/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/mps/xyz/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,13 +82,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/mps/xyzp3/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/mps/xyzp3/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,13 +82,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/options/OptionsIT/no_options_at_all/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/options/OptionsIT/no_options_at_all/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/options/OptionsIT/option_debug/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/options/OptionsIT/option_debug/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/options/OptionsIT/option_quiet_logfile/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/options/OptionsIT/option_quiet_logfile/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/options/OptionsOnClassIT/option_debug/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/options/OptionsOnClassIT/option_debug/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/MetaAnnotationProfileIT/profile_1_2_3/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/MetaAnnotationProfileIT/profile_1_2_3/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,16 +82,31 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
   <profiles>
     <profile>
       <id>profile-1</id>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/no_profile_at_all/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/no_profile_at_all/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,20 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
-<build>
+  <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>com.soebes.maven.plugins</groupId>
           <artifactId>echo-maven-plugin</artifactId>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/profile_1/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/profile_1/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,16 +82,32 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <profiles>
     <profile>
       <id>profile-1</id>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/profile_1_2/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/profile_1_2/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,16 +82,32 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
   <profiles>
     <profile>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/profile_1_2_3/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/profile_1_2_3/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,13 +82,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -96,6 +96,15 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>com.soebes.maven.plugins</groupId>
           <artifactId>echo-maven-plugin</artifactId>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/unknown_profile/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileIT/unknown_profile/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,14 +82,30 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileOnClassIT/profile_1/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileOnClassIT/profile_1/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -67,6 +67,11 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.apiguardian</groupId>
       <artifactId>apiguardian-api</artifactId>
@@ -86,13 +91,23 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
   <profiles>
     <profile>
       <id>profile-1</id>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileOnClassIT/profile_1_2_3/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/ProfileOnClassIT/profile_1_2_3/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -67,6 +67,11 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.apiguardian</groupId>
       <artifactId>apiguardian-api</artifactId>
@@ -86,16 +91,20 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>com.soebes.maven.plugins</groupId>
           <artifactId>echo-maven-plugin</artifactId>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/packagewide/ProfileOnPackageIT/profile_1_2_3/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/profiles/packagewide/ProfileOnPackageIT/profile_1_2_3/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -82,13 +82,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/properties/MetaAnnotationPropertiesIT/property_skiptests/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/properties/MetaAnnotationPropertiesIT/property_skiptests/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -66,6 +66,22 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.apiguardian</groupId>
@@ -82,13 +98,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/properties/PropertiesIT/property_skiptests/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/properties/PropertiesIT/property_skiptests/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -92,4 +92,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/properties/PropertiesOnClassIT/property_skiptests/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/properties/PropertiesOnClassIT/property_skiptests/pom.xml
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/itf-examples/src/test/resources-its/com/soebes/itf/examples/properties/PropertiesOnNestedClassIT/Level1/property_skiptests/pom.xml
+++ b/itf-examples/src/test/resources-its/com/soebes/itf/examples/properties/PropertiesOnNestedClassIT/Level1/property_skiptests/pom.xml
@@ -82,14 +82,29 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,15 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs combine.self="append">
+              <arg>-Xlint:-options</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
             <archive>


### PR DESCRIPTION
 - Upgraded equalsverifier to 3.15.4
 - Changed the order of deps in pom's to have equalsverifier before asserj-core
 - Added compiler configuration to suppress WARNINGs for obosolete source 8 level
